### PR TITLE
feat: app hash error channel

### DIFF
--- a/blocksync/reactor.go
+++ b/blocksync/reactor.go
@@ -433,6 +433,6 @@ func (bcR *Reactor) BroadcastStatusRequest() {
 	})
 }
 
-func (r *Reactor) AppHashErrorsCh() chan p2p.AppHashError {
-	return r.appHashErrorsCh
+func (bcR *Reactor) AppHashErrorsCh() chan p2p.AppHashError {
+	return bcR.appHashErrorsCh
 }

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -605,4 +605,4 @@ func (br *ByzantineReactor) ReceiveEnvelope(e p2p.Envelope) {
 
 func (br *ByzantineReactor) InitPeer(peer p2p.Peer) p2p.Peer { return peer }
 
-func (br *ByzantineReactor) AppHashErrorsCh() <-chan p2p.AppHashError { return nil }
+func (br *ByzantineReactor) AppHashErrorsCh() chan p2p.AppHashError { return nil }

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -604,3 +604,5 @@ func (br *ByzantineReactor) ReceiveEnvelope(e p2p.Envelope) {
 }
 
 func (br *ByzantineReactor) InitPeer(peer p2p.Peer) p2p.Peer { return peer }
+
+func (br *ByzantineReactor) AppHashErrorsCh() <-chan p2p.AppHashError { return nil }

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -282,6 +282,6 @@ func (m *TxsMessage) String() string {
 	return fmt.Sprintf("[TxsMessage %v]", m.Txs)
 }
 
-func (memR *Reactor) AppHashErrorsCh() <-chan p2p.AppHashError {
+func (memR *Reactor) AppHashErrorsCh() chan p2p.AppHashError {
 	return memR.appHashErrorsCh
 }

--- a/mempool/v1/reactor.go
+++ b/mempool/v1/reactor.go
@@ -21,9 +21,10 @@ import (
 // peers you received it from.
 type Reactor struct {
 	p2p.BaseReactor
-	config  *cfg.MempoolConfig
-	mempool *TxMempool
-	ids     *mempoolIDs
+	config          *cfg.MempoolConfig
+	mempool         *TxMempool
+	ids             *mempoolIDs
+	appHashErrorsCh chan p2p.AppHashError
 }
 
 type mempoolIDs struct {
@@ -279,4 +280,8 @@ type TxsMessage struct {
 // String returns a string representation of the TxsMessage.
 func (m *TxsMessage) String() string {
 	return fmt.Sprintf("[TxsMessage %v]", m.Txs)
+}
+
+func (memR *Reactor) AppHashErrorsCh() <-chan p2p.AppHashError {
+	return memR.appHashErrorsCh
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1255,6 +1255,11 @@ func (n *Node) ConsensusReactor() *cs.Reactor {
 	return n.consensusReactor
 }
 
+// BCReactor returns the Node's BlockchainReactor.
+func (n *Node) BCReactor() p2p.Reactor {
+	return n.bcReactor
+}
+
 // MempoolReactor returns the Node's mempool reactor.
 func (n *Node) MempoolReactor() p2p.Reactor {
 	return n.mempoolReactor

--- a/p2p/base_reactor.go
+++ b/p2p/base_reactor.go
@@ -1,9 +1,20 @@
 package p2p
 
 import (
+	"fmt"
+
 	"github.com/cometbft/cometbft/libs/service"
 	"github.com/cometbft/cometbft/p2p/conn"
 )
+
+type AppHashError struct {
+	Err    error
+	Height uint64
+}
+
+func (e AppHashError) Error() string {
+	return fmt.Sprintf("app hash error at height %v: %s", e.Height, e.Err.Error())
+}
 
 // Reactor is responsible for handling incoming messages on one or more
 // Channel. Switch calls GetChannels when reactor is added to it. When a new
@@ -41,6 +52,8 @@ type Reactor interface {
 	// ReceiveEnvelope is called by the switch when an envelope is received from any connected
 	// peer on any of the channels registered by the reactor.
 	ReceiveEnvelope(Envelope)
+
+	AppHashErrorsCh() <-chan AppHashError
 }
 
 //--------------------------------------
@@ -66,3 +79,4 @@ func (*BaseReactor) AddPeer(peer Peer)                        {}
 func (*BaseReactor) RemovePeer(peer Peer, reason interface{}) {}
 func (*BaseReactor) ReceiveEnvelope(e Envelope)               {}
 func (*BaseReactor) InitPeer(peer Peer) Peer                  { return peer }
+func (*BaseReactor) AppHashErrorsCh() <-chan AppHashError     { return nil }

--- a/p2p/base_reactor.go
+++ b/p2p/base_reactor.go
@@ -53,7 +53,9 @@ type Reactor interface {
 	// peer on any of the channels registered by the reactor.
 	ReceiveEnvelope(Envelope)
 
-	AppHashErrorsCh() <-chan AppHashError
+	// AppHashErrorsCh is used to stream hash errors to the sdk, which is then used
+	// to provide further debugging information in logs to the user.
+	AppHashErrorsCh() chan AppHashError
 }
 
 //--------------------------------------
@@ -61,12 +63,14 @@ type Reactor interface {
 type BaseReactor struct {
 	service.BaseService // Provides Start, Stop, .Quit
 	Switch              *Switch
+	AppHashErrorChanBR  chan AppHashError
 }
 
 func NewBaseReactor(name string, impl Reactor) *BaseReactor {
 	return &BaseReactor{
-		BaseService: *service.NewBaseService(nil, name, impl),
-		Switch:      nil,
+		BaseService:        *service.NewBaseService(nil, name, impl),
+		Switch:             nil,
+		AppHashErrorChanBR: impl.AppHashErrorsCh(),
 	}
 }
 
@@ -79,4 +83,4 @@ func (*BaseReactor) AddPeer(peer Peer)                        {}
 func (*BaseReactor) RemovePeer(peer Peer, reason interface{}) {}
 func (*BaseReactor) ReceiveEnvelope(e Envelope)               {}
 func (*BaseReactor) InitPeer(peer Peer) Peer                  { return peer }
-func (*BaseReactor) AppHashErrorsCh() <-chan AppHashError     { return nil }
+func (*BaseReactor) AppHashErrorsCh() chan AppHashError       { return nil }


### PR DESCRIPTION
This PR implements an error channel which allows cometBFT to stream app hash errors to the sdk. With this information, the sdk can provide a more useful error message, specifically the hash of every module at the problematic block height.

![Screenshot 2024-01-02 at 9 58 28 PM](https://github.com/osmosis-labs/cometbft/assets/40078083/aec2f20b-0414-4736-bb63-458bdec7e548)

The respective cosmos sdk PR: https://github.com/osmosis-labs/cosmos-sdk/pull/500
