### PR TITLE
fix(blocksync): use timer instead of time.After

### DIFF
--- a/blocksync/pool.go
+++ b/blocksync/pool.go
@@ -720,11 +720,11 @@ PICK_PEER_LOOP:
 
 // Picks a second peer and sends a request to it. If the second peer is already
 // set, does nothing.
-func (bpr *bpRequester) pickSecondPeerAndSendRequest() {
+func (bpr *bpRequester) pickSecondPeerAndSendRequest() (picked bool) {
 	bpr.mtx.Lock()
 	if bpr.secondPeerID != "" {
 		bpr.mtx.Unlock()
-		return
+		return false
 	}
 	peerID := bpr.peerID
 	bpr.mtx.Unlock()
@@ -736,7 +736,10 @@ func (bpr *bpRequester) pickSecondPeerAndSendRequest() {
 		bpr.mtx.Unlock()
 
 		bpr.pool.sendRequest(bpr.height, secondPeer.id)
+		return true
 	}
+
+	return false
 }
 
 // Informs the requester of a new pool's height.
@@ -761,6 +764,9 @@ OUTER_LOOP:
 			bpr.pickSecondPeerAndSendRequest()
 		}
 
+		retryTimer := time.NewTimer(requestRetrySeconds * time.Second)
+		defer retryTimer.Stop()
+
 		for {
 			select {
 			case <-bpr.pool.Quit():
@@ -770,7 +776,7 @@ OUTER_LOOP:
 				return
 			case <-bpr.Quit():
 				return
-			case <-time.After(requestRetrySeconds * time.Second):
+			case <-retryTimer.C:
 				if !gotBlock {
 					bpr.Logger.Debug("Retrying block request(s) after timeout", "height", bpr.height, "peer", bpr.peerID, "secondPeerID", bpr.secondPeerID)
 					bpr.reset(bpr.peerID)
@@ -787,12 +793,21 @@ OUTER_LOOP:
 				// If both peers returned NoBlockResponse or bad block, reschedule both
 				// requests. If not, wait for the other peer.
 				if len(bpr.requestedFrom()) == 0 {
+					retryTimer.Stop()
 					continue OUTER_LOOP
 				}
 			case newHeight := <-bpr.newHeightCh:
 				if !gotBlock && bpr.height-newHeight < minBlocksForSingleRequest {
 					// The operation is a noop if the second peer is already set. The cost is checking a mutex.
-					bpr.pickSecondPeerAndSendRequest()
+					//
+					// If the second peer was just set, reset the retryTimer to give the
+					// second peer a chance to respond.
+					if picked := bpr.pickSecondPeerAndSendRequest(); picked {
+						if !retryTimer.Stop() {
+							<-retryTimer.C
+						}
+						retryTimer.Reset(requestRetrySeconds * time.Second)
+					}
 				}
 			case <-bpr.gotBlockCh:
 				gotBlock = true


### PR DESCRIPTION
`time.After` gets reset after each iteration of the `for` loop, which is not what we want. We want the timer to fire after 30 sec if both peers (first and second) don't respond.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

