### PR TITLE
perf(libs/json): Lower heap overhead of JSON encoding (backport #2846…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* [#27](https://github.com/osmosis-labs/cometbft/pull/27) Lower allocation overhead of txIndex matchRange
+* [#28](https://github.com/osmosis-labs/cometbft/pull/28) Significantly speedup bitArray.PickRandom
+* [#29](https://github.com/osmosis-labs/cometbft/pull/29) Lower heap overhead of JSON encoding
+
 ## v0.37.4-v24-osmo-3
 
 * [#21](https://github.com/osmosis-labs/cometbft/pull/21) Move websocket logs to Debug

--- a/libs/json/encoder_test.go
+++ b/libs/json/encoder_test.go
@@ -102,3 +102,20 @@ func TestMarshal(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkJsonMarshalStruct(b *testing.B) {
+	s := "string"
+	sPtr := &s
+	i64 := int64(64)
+	ti := time.Date(2020, 6, 2, 18, 5, 13, 4346374, time.FixedZone("UTC+2", 2*60*60))
+	car := &Car{Wheels: 4}
+	boat := Boat{Sail: true}
+	for i := 0; i < b.N; i++ {
+		_, _ = json.Marshal(Struct{
+			Bool: true, Float64: 3.14, Int32: 32, Int64: 64, Int64Ptr: &i64,
+			String: "foo", StringPtrPtr: &sPtr, Bytes: []byte{1, 2, 3},
+			Time: ti, Car: car, Boat: boat, Vehicles: []Vehicle{car, boat},
+			Child: &Struct{Bool: false, String: "child"}, private: "private",
+		})
+	}
+}


### PR DESCRIPTION
…) (#2876)

---

Many RPC methods require JSON marshalled responses. We saw this taking a notable amount of heap allocation in query serving full nodes. This PR removes some extra heap allocations that were being done. We avoided using the more efficient encoder.Encode before, because it added a newline. This PR changes the function signature for these private methods to be using *bytes.Buffer, and then uses the in-buffer methods (rather than a second copy). We then just truncate the final byte after each such call, which does not waste any allocations.

I added a benchmark for the most complex test case.

OLD:
```
BenchmarkJsonMarshalStruct-12              78992             15542 ns/op            4487 B/op        191 allocs/op
```
New:
```
BenchmarkJsonMarshalStruct-12              93346             11132 ns/op            3245 B/op         58 allocs/op
```

Roughly a 3-4x reduction in the number of allocations, and 20% speedup.

- [x] Tests written/updated - Existing tests cover this
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec <hr>This is an automatic backport of pull request #2846 done by [Mergify](https://mergify.com).

---------

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

