### PR TITLE
perf(state): Cache the block hash #2924

### DIFF
--- a/.changelog/unreleased/improvements/2924-consensus-cache-block-hash.md
+++ b/.changelog/unreleased/improvements/2924-consensus-cache-block-hash.md
@@ -1,0 +1,2 @@
+- `[state/execution]` Cache the block hash computation inside of the Block Type, so we only compute it once.
+  ([\#2924](https://github.com/cometbft/cometbft/pull/2924))

--- a/.changelog/unreleased/improvements/2924-consensus-cache-block-hash.md
+++ b/.changelog/unreleased/improvements/2924-consensus-cache-block-hash.md
@@ -1,2 +1,0 @@
-- `[state/execution]` Cache the block hash computation inside of the Block Type, so we only compute it once.
-  ([\#2924](https://github.com/cometbft/cometbft/pull/2924))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* [#27](https://github.com/osmosis-labs/cometbft/pull/27) Lower allocation overhead of txIndex matchRange
+* [#28](https://github.com/osmosis-labs/cometbft/pull/28) Significantly speedup bitArray.PickRandom
+* [#29](https://github.com/osmosis-labs/cometbft/pull/29) Lower heap overhead of JSON encoding
+* [#30](https://github.com/osmosis-labs/cometbft/pull/30) Cache the block hash
+
 ## v0.37.4-v24-osmo-3
 
 * [#21](https://github.com/osmosis-labs/cometbft/pull/21) Move websocket logs to Debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.37.4-v24-osmo-4
+
 * [#27](https://github.com/osmosis-labs/cometbft/pull/27) Lower allocation overhead of txIndex matchRange
 * [#28](https://github.com/osmosis-labs/cometbft/pull/28) Significantly speedup bitArray.PickRandom
 * [#29](https://github.com/osmosis-labs/cometbft/pull/29) Lower heap overhead of JSON encoding

--- a/types/block.go
+++ b/types/block.go
@@ -43,10 +43,11 @@ const (
 type Block struct {
 	mtx cmtsync.Mutex
 
-	Header     `json:"header"`
-	Data       `json:"data"`
-	Evidence   EvidenceData `json:"evidence"`
-	LastCommit *Commit      `json:"last_commit"`
+	verifiedHash cmtbytes.HexBytes // Verified block hash (not included in the struct hash)
+	Header       `json:"header"`
+	Data         `json:"data"`
+	Evidence     EvidenceData `json:"evidence"`
+	LastCommit   *Commit      `json:"last_commit"`
 }
 
 // ValidateBasic performs basic validation that doesn't involve state data.
@@ -130,8 +131,13 @@ func (b *Block) Hash() cmtbytes.HexBytes {
 	if b.LastCommit == nil {
 		return nil
 	}
+	if b.verifiedHash != nil {
+		return b.verifiedHash
+	}
 	b.fillHeader()
-	return b.Header.Hash()
+	hash := b.Header.Hash()
+	b.verifiedHash = hash
+	return hash
 }
 
 // MakePartSet returns a PartSet containing parts of a serialized block.


### PR DESCRIPTION
Closes https://github.com/cometbft/cometbft/issues/2923

Caches the block hash to ensure we only compute it once in consensus execution.

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

