### PR TITLE
perf(consensus/blockstore): Remove validate basic call from LoadBlock…

### DIFF
--- a/.changelog/unreleased/improvements/2964-skip-revalidation-of-blockstore-LoadBlockFromMeta-.md
+++ b/.changelog/unreleased/improvements/2964-skip-revalidation-of-blockstore-LoadBlockFromMeta-.md
@@ -1,0 +1,2 @@
+- `[blockstore]` Remove a redundant `Header.ValidateBasic` call in `LoadBlockMeta`, 75% reducing this time.
+  ([\#2964](https://github.com/cometbft/cometbft/pull/2964))

--- a/store/store.go
+++ b/store/store.go
@@ -192,7 +192,7 @@ func (bs *BlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 		panic(fmt.Errorf("unmarshal to cmtproto.BlockMeta: %w", err))
 	}
 
-	blockMeta, err := types.BlockMetaFromProto(pbbm)
+	blockMeta, err := types.BlockMetaFromTrustedProto(pbbm)
 	if err != nil {
 		panic(fmt.Errorf("error from proto blockMeta: %w", err))
 	}

--- a/types/block_meta.go
+++ b/types/block_meta.go
@@ -41,6 +41,14 @@ func (bm *BlockMeta) ToProto() *cmtproto.BlockMeta {
 }
 
 func BlockMetaFromProto(pb *cmtproto.BlockMeta) (*BlockMeta, error) {
+	bm, err := BlockMetaFromTrustedProto(pb)
+	if err != nil {
+		return nil, err
+	}
+	return bm, bm.ValidateBasic()
+}
+
+func BlockMetaFromTrustedProto(pb *cmtproto.BlockMeta) (*BlockMeta, error) {
 	if pb == nil {
 		return nil, errors.New("blockmeta is empty")
 	}
@@ -62,7 +70,7 @@ func BlockMetaFromProto(pb *cmtproto.BlockMeta) (*BlockMeta, error) {
 	bm.Header = h
 	bm.NumTxs = int(pb.NumTxs)
 
-	return bm, bm.ValidateBasic()
+	return bm, nil
 }
 
 // ValidateBasic performs basic validation.

--- a/types/block_meta_test.go
+++ b/types/block_meta_test.go
@@ -34,7 +34,7 @@ func TestBlockMeta_ToProto(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			pb := tt.bm.ToProto()
 
-			bm, err := BlockMetaFromProto(pb)
+			bm, err := BlockMetaFromTrustedProto(pb)
 
 			if !tt.expErr {
 				require.NoError(t, err, tt.testName)


### PR DESCRIPTION
…Meta (backport #2964) (#2998)

Our gossip block parts routine calls `Blockstore.LoadBlockMeta` (as do things in blocksync). This currently takes some time due to ValidateBasic:

![image](https://github.com/cometbft/cometbft/assets/6440154/2f4471b0-0744-44de-ab94-4a9a4596712c)

However note that we only save validated data to the blockstore. We only do it in:
- Commit: https://github.com/cometbft/cometbft/blob/main/internal/consensus/state.go#L1867
- Blocksync after validation: https://github.com/cometbft/cometbft/blob/main/internal/consensus/state.go#L1867

Hence the validate basic time is wasted.

This should eventually just go to an LRU cache to even avoid the proto unmarshalling (as should ~everything in blockstore) but we want this anyway to reduce the computational overhead,

WRT live consensus, in main this only helps with catchup for live syncing nodes, I haven't checked on v0.47.x, but the cpuprofile suggests it may help with active block gossip time as well?

---

#### PR checklist

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec <hr>This is an automatic backport of pull request #2964 done by [Mergify](https://mergify.com).

---------

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

