### PR TITLE
fix: TimeoutTicker returns wrong value/timeout pair when timeouts are…

### DIFF
--- a/.changelog/unreleased/bug-fixes/3092-consensus-timeout-ticker-data-race.md
+++ b/.changelog/unreleased/bug-fixes/3092-consensus-timeout-ticker-data-race.md
@@ -1,0 +1,2 @@
+- `[consensus]` Fix a race condition in the consensus timeout ticker. Race is caused by two timeouts being scheduled at the same time.
+  ([\#3092](https://github.com/cometbft/cometbft/pull/2136))

--- a/consensus/ticker.go
+++ b/consensus/ticker.go
@@ -31,17 +31,21 @@ type TimeoutTicker interface {
 type timeoutTicker struct {
 	service.BaseService
 
-	timer    *time.Timer
-	tickChan chan timeoutInfo // for scheduling timeouts
-	tockChan chan timeoutInfo // for notifying about them
+	timerActive bool
+	timer       *time.Timer
+	tickChan    chan timeoutInfo // for scheduling timeouts
+	tockChan    chan timeoutInfo // for notifying about them
 }
 
 // NewTimeoutTicker returns a new TimeoutTicker.
 func NewTimeoutTicker() TimeoutTicker {
 	tt := &timeoutTicker{
-		timer:    time.NewTimer(0),
-		tickChan: make(chan timeoutInfo, tickTockBufferSize),
-		tockChan: make(chan timeoutInfo, tickTockBufferSize),
+		timer: time.NewTimer(0),
+		// An indicator variable to check if the timer is active or not.
+		// Concurrency safe because the timer is only accessed by a single goroutine.
+		timerActive: true,
+		tickChan:    make(chan timeoutInfo, tickTockBufferSize),
+		tockChan:    make(chan timeoutInfo, tickTockBufferSize),
 	}
 	tt.BaseService = *service.NewBaseService(nil, "TimeoutTicker", tt)
 	tt.stopTimer() // don't want to fire until the first scheduled timeout
@@ -59,7 +63,6 @@ func (t *timeoutTicker) OnStart() error {
 // OnStop implements service.Service. It stops the timeout routine.
 func (t *timeoutTicker) OnStop() {
 	t.BaseService.OnStop()
-	t.stopTimer()
 }
 
 // Chan returns a channel on which timeouts are sent.
@@ -76,21 +79,23 @@ func (t *timeoutTicker) ScheduleTimeout(ti timeoutInfo) {
 
 //-------------------------------------------------------------
 
-// stop the timer and drain if necessary
+// if the timer is active, stop it and drain the channel.
 func (t *timeoutTicker) stopTimer() {
+	if !t.timerActive {
+		return
+	}
 	// Stop() returns false if it was already fired or was stopped
 	if !t.timer.Stop() {
-		select {
-		case <-t.timer.C:
-		default:
-			t.Logger.Debug("Timer already stopped")
-		}
+		<-t.timer.C
 	}
+	t.timerActive = false
 }
 
 // send on tickChan to start a new timer.
-// timers are interupted and replaced by new ticks from later steps
-// timeouts of 0 on the tickChan will be immediately relayed to the tockChan
+// timers are interrupted and replaced by new ticks from later steps
+// timeouts of 0 on the tickChan will be immediately relayed to the tockChan.
+// NOTE: timerActive is not concurrency safe, but it's only accessed in NewTimer and timeoutRoutine,
+// making it single-threaded access.
 func (t *timeoutTicker) timeoutRoutine() {
 	t.Logger.Debug("Starting timeout routine")
 	var ti timeoutInfo
@@ -112,15 +117,18 @@ func (t *timeoutTicker) timeoutRoutine() {
 				}
 			}
 
-			// stop the last timer
+			// stop the last timer if it exists
 			t.stopTimer()
 
-			// update timeoutInfo and reset timer
+			// update timeoutInfo, reset timer, and mark timer as active
 			// NOTE time.Timer allows duration to be non-positive
 			ti = newti
 			t.timer.Reset(ti.Duration)
+			t.timerActive = true
+
 			t.Logger.Debug("Scheduled timeout", "dur", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
 		case <-t.timer.C:
+			t.timerActive = false
 			t.Logger.Info("Timed out", "dur", ti.Duration, "height", ti.Height, "round", ti.Round, "step", ti.Step)
 			// go routine here guarantees timeoutRoutine doesn't block.
 			// Determinism comes from playback in the receiveRoutine.
@@ -128,6 +136,7 @@ func (t *timeoutTicker) timeoutRoutine() {
 			//  and managing the timeouts ourselves with a millisecond ticker
 			go func(toi timeoutInfo) { t.tockChan <- toi }(ti)
 		case <-t.Quit():
+			t.stopTimer()
 			return
 		}
 	}

--- a/consensus/ticker_test.go
+++ b/consensus/ticker_test.go
@@ -1,0 +1,40 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cometbft/cometbft/consensus/types"
+)
+
+func TestTimeoutTicker(t *testing.T) {
+	ticker := NewTimeoutTicker()
+	err := ticker.Start()
+	require.NoError(t, err)
+	defer func() {
+		err := ticker.Stop()
+		require.NoError(t, err)
+	}()
+
+	c := ticker.Chan()
+	for i := 1; i <= 10; i++ {
+		height := int64(i)
+
+		startTime := time.Now()
+		// Schedule a timeout for 5ms from now
+		negTimeout := timeoutInfo{Duration: -1 * time.Millisecond, Height: height, Round: 0, Step: types.RoundStepNewHeight}
+		timeout := timeoutInfo{Duration: 5 * time.Millisecond, Height: height, Round: 0, Step: types.RoundStepNewRound}
+		ticker.ScheduleTimeout(negTimeout)
+		ticker.ScheduleTimeout(timeout)
+
+		// Wait for the timeout to be received
+		to := <-c
+		endTime := time.Now()
+		elapsedTime := endTime.Sub(startTime)
+		if timeout == to {
+			require.True(t, elapsedTime >= timeout.Duration, "We got the 5ms timeout. However the timeout happened too quickly. Should be >= 5ms. Got %dms (start time %d end time %d)", elapsedTime.Milliseconds(), startTime.UnixMilli(), endTime.UnixMilli())
+		}
+	}
+}


### PR DESCRIPTION
… scheduled at ~approximately the same time (backport #3092) (#3107)

#3091 

The problem is we have an edge case where we should drain the timer channel, but we "let it slide" in certain race conditions when two timeouts are scheduled near each other. This means we can have unsafe timeout behavior as demonstrated in the github issue, and likely more spots in consensus.

Notice that aside from NewTimer and OnStop, all timer accesses are from the same thread. In NewTimer we can block until the timer is drained (very quickly up to goroutine scheduling). In OnStop we don't need to guarantee draining before the method ends, we can just launch something into the channel that will kill it.

In the main timer goroutine, we can safely maintain this "timerActive" variable, and force drain when its active. This removes the edge case.

The test I created does fail on main.


---

#### PR checklist

- [X] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec <hr>This is an automatic backport of pull request #3092 done by [Mergify](https://mergify.com).

---------

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

