### PR TITLE
perf(consensus): add simplistic block validation cache (#3070)

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -36,6 +36,9 @@ type BlockExecutor struct {
 	mempool mempool.Mempool
 	evpool  EvidencePool
 
+	// 1-element cache of validated blocks
+	lastValidatedBlock *types.Block
+
 	logger log.Logger
 
 	metrics *Metrics
@@ -172,9 +175,11 @@ func (blockExec *BlockExecutor) ProcessProposal(
 // Validation does not mutate state, but does require historical information from the stateDB,
 // ie. to verify evidence from a validator at an old height.
 func (blockExec *BlockExecutor) ValidateBlock(state State, block *types.Block) error {
-	err := validateBlock(state, block)
-	if err != nil {
-		return err
+	if !blockExec.lastValidatedBlock.HashesTo(block.Hash()) {
+		if err := validateBlock(state, block); err != nil {
+			return err
+		}
+		blockExec.lastValidatedBlock = block
 	}
 	return blockExec.evpool.CheckEvidence(block.Evidence.Evidence)
 }
@@ -195,11 +200,12 @@ func (blockExec *BlockExecutor) ApplyVerifiedBlock(
 func (blockExec *BlockExecutor) ApplyBlock(
 	state State, blockID types.BlockID, block *types.Block,
 ) (State, int64, error) {
-
-	if err := validateBlock(state, block); err != nil {
-		return state, 0, ErrInvalidBlock(err)
+	if !blockExec.lastValidatedBlock.HashesTo(block.Hash()) {
+		if err := validateBlock(state, block); err != nil {
+			return state, 0, ErrInvalidBlock(err)
+		}
+		blockExec.lastValidatedBlock = block
 	}
-
 	return blockExec.applyBlock(state, blockID, block)
 }
 


### PR DESCRIPTION
Closes #2854

Follow up from #2960

This PR adds a simplistic 1-element block validation cache in `BlockExecutor`. This addresses a performance bottleneck raised as part of #2854

---

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [ ] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec

---------

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

