### PR TITLE
perf: Speedup flowrate by removing time.Now() from every update call …

### DIFF
--- a/.changelog/unreleased/improvements/3016-remove-expensive-calls-from-flowrate.md
+++ b/.changelog/unreleased/improvements/3016-remove-expensive-calls-from-flowrate.md
@@ -1,0 +1,3 @@
+- [`flowrate`] Remove expensive time.Now() calls from flowrate calls.
+  Changes clock updates to happen in a separate goroutine.
+  ([\#3016](https://github.com/cometbft/cometbft/issues/3016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * [#83](https://github.com/osmosis-labs/cometbft/pull/83)  perf(types): 3x speedup MakePartSet (#3117)
+* [#85](https://github.com/osmosis-labs/cometbft/pull/85)  perf(flowrate): Speedup flowrate.Clock (#3016)
 
 
 ## v0.37.4-v25-osmo-5

--- a/libs/flowrate/flowrate.go
+++ b/libs/flowrate/flowrate.go
@@ -47,6 +47,7 @@ type Monitor struct {
 // The default values for sampleRate and windowSize (if <= 0) are 100ms and 1s,
 // respectively.
 func New(sampleRate, windowSize time.Duration) *Monitor {
+	ensureClockRunning()
 	if sampleRate = clockRound(sampleRate); sampleRate <= 0 {
 		sampleRate = 5 * clockRate
 	}

--- a/libs/flowrate/util.go
+++ b/libs/flowrate/util.go
@@ -7,29 +7,56 @@ package flowrate
 import (
 	"math"
 	"strconv"
+	"sync/atomic"
 	"time"
 )
 
 // clockRate is the resolution and precision of clock().
 const clockRate = 20 * time.Millisecond
 
-// czero is the process start time rounded down to the nearest clockRate
-// increment.
-var czero = time.Now().Round(clockRate)
+var (
+	hasInitializedClock = atomic.Bool{}
+	currentClockValue   = atomic.Int64{}
+	clockStartTime      = time.Time{}
+)
+
+// checks if the clock update timer is running. If not, sets clockStartTime and starts it.
+func ensureClockRunning() {
+	firstRun := hasInitializedClock.CompareAndSwap(false, true)
+	if !firstRun {
+		return
+	}
+	clockStartTime = time.Now().Round(clockRate)
+	go runClockUpdates()
+}
+
+// increments the current clock value every clockRate interval.
+func runClockUpdates() {
+	// Create a ticker that sends the current time on the channel every clockRate interval
+	ticker := time.Tick(clockRate)
+
+	// First tick happens after clockrate, therefore initial value is 0.
+	for t := range ticker {
+		delta := t.Sub(clockStartTime)
+		rounded := clockRound(delta)
+		currentClockValue.Store(int64(rounded))
+	}
+}
 
 // clock returns a low resolution timestamp relative to the process start time.
 func clock() time.Duration {
-	return time.Now().Round(clockRate).Sub(czero)
+	return time.Duration(currentClockValue.Load())
 }
 
 // clockToTime converts a clock() timestamp to an absolute time.Time value.
 func clockToTime(c time.Duration) time.Time {
-	return czero.Add(c)
+	return clockStartTime.Add(c)
 }
 
 // clockRound returns d rounded to the nearest clockRate increment.
 func clockRound(d time.Duration) time.Duration {
-	return (d + clockRate>>1) / clockRate * clockRate
+	//nolint:durationcheck
+	return ((d + clockRate>>1) / clockRate) * clockRate
 }
 
 // round returns x rounded to the nearest int64 (non-negative values only).


### PR DESCRIPTION
…(#3016)

Closes #2958
Speeds up flowrate by removing time.Now() calls from every `clock` call, instead making one goroutine responsible for all clock reads. On my most recent mainnet benchmark, this should shave 14% off of the synchronous time in sending packets:

![image](https://github.com/cometbft/cometbft/assets/6440154/f2f65080-7bf1-4c4c-9775-774d97ed016a)

There may be slight differences at the boundary of these 20ms windows, but I do not think that is important.

---

- [x] Tests written/updated - existing tests pass
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

