### PR TITLE
Just resetUpdate Mempool on propose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* [#113](https://github.com/osmosis-labs/cometbft/pull/113), [#114](https://github.com/osmosis-labs/cometbft/pull/114) perf(consensus): Make consensus never block on Mempool Updates.
+
 ## v0.37.4-v25-osmo-9
 
 * [#112](https://github.com/osmosis-labs/cometbft/pull/112)  perf(mempool): Remove expensive debug logs + repeated hashing in mempool. Fix some v0.37.x line hard-to-reach race bugs. (Not in upstream)

--- a/state/execution.go
+++ b/state/execution.go
@@ -110,6 +110,7 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 	// Fetch a limited amount of valid txs
 	maxDataBytes := types.MaxDataBytes(maxBytes, evSize, state.Validators.Size())
 
+	blockExec.mempool.ResetUpdate()
 	txs := blockExec.mempool.ReapMaxBytesMaxGas(maxDataBytes, maxGas)
 	block := state.MakeBlock(height, txs, commit, evidence, proposerAddr)
 


### PR DESCRIPTION
Just call resetUpdate right before we reap. The only risk is in a case where the proposer has rechecked like 10 txs (since its super slow), but you reap like 100 txs. But all that happens then is you as the proposer just propose some txs that may fail recheck. (Which may already happen)

If thats really a problem, thats now the app's problem :) 

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

