### PR TITLE
perf(blockstore)!: Cache more in blockstore, which speedsup the gossip routines #3342 

### DIFF
--- a/.changelog/unreleased/improvements/3342-improve-blockstore-caches.md
+++ b/.changelog/unreleased/improvements/3342-improve-blockstore-caches.md
@@ -1,0 +1,3 @@
+- `[blockstore]` Use LRU caches for LoadBlockPart. Make the LoadBlockPart and LoadBlockCommit APIs 
+    return mutative copies, that the caller is expected to not modify. This saves on memory copying.
+  ([\#3342](https://github.com/cometbft/cometbft/issues/3342))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v0.37.4-v25-osmo-10
 
 * [#115](https://github.com/osmosis-labs/cometbft/pull/115) perf(p2p/secretconn): Buffer secret connection writes (#3346)
-
+* [#116](https://github.com/osmosis-labs/cometbft/pull/116) perf(blockstore)!: Cache more in blockstore, which speedsup the gossip routines (#3342)
 
 ## v0.37.4-v25-osmo-9
 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -58,10 +58,11 @@ type ReactorOption func(*Reactor)
 // consensusState.
 func NewReactor(consensusState *State, waitSync bool, options ...ReactorOption) *Reactor {
 	conR := &Reactor{
-		conS:     consensusState,
-		waitSync: waitSync,
-		rs:       consensusState.GetRoundState(),
-		Metrics:  NopMetrics(),
+		conS:          consensusState,
+		waitSync:      waitSync,
+		rs:            consensusState.GetRoundState(),
+		initialHeight: consensusState.state.InitialHeight,
+		Metrics:       NopMetrics(),
 	}
 	conR.BaseReactor = *p2p.NewBaseReactor("Consensus", conR)
 

--- a/evidence/verify.go
+++ b/evidence/verify.go
@@ -276,7 +276,7 @@ func getSignedHeader(blockStore BlockStore, height int64) (*types.SignedHeader, 
 	if blockMeta == nil {
 		return nil, fmt.Errorf("don't have header at height #%d", height)
 	}
-	commit := blockStore.LoadBlockCommit(height)
+	commit := blockStore.LoadBlockCommit(height).Clone()
 	if commit == nil {
 		return nil, fmt.Errorf("don't have commit at height #%d", height)
 	}

--- a/p2p/conn/secret_connection.go
+++ b/p2p/conn/secret_connection.go
@@ -45,7 +45,7 @@ const (
 	labelDHSecret                = "DH_SECRET"
 	labelSecretConnectionMac     = "SECRET_CONNECTION_MAC"
 
-	defaultWriteBufferSize = 1024 * 1024
+	defaultWriteBufferSize = 128 * 1024
 	defaultReadBufferSize  = 65536
 )
 

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -161,7 +161,7 @@ func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, erro
 	}
 
 	// Return the canonical commit (comes from the block at height+1)
-	commit := env.BlockStore.LoadBlockCommit(height)
+	commit := env.BlockStore.LoadBlockCommit(height).Clone()
 	return ctypes.NewResultCommit(&header, commit, true), nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -365,13 +365,16 @@ func (bs *BlockStore) PruneBlocks(height int64) (uint64, error) {
 		if err := batch.Delete(calcBlockCommitKey(h)); err != nil {
 			return 0, err
 		}
+		bs.blockCommitCache.Remove(h)
 		if err := batch.Delete(calcSeenCommitKey(h)); err != nil {
 			return 0, err
 		}
+		bs.seenCommitCache.Remove(h)
 		for p := 0; p < int(meta.BlockID.PartSetHeader.Total); p++ {
 			if err := batch.Delete(calcBlockPartKey(h, p)); err != nil {
 				return 0, err
 			}
+			bs.blockPartCache.Remove(blockPartIndex{h, p})
 		}
 		pruned++
 


### PR DESCRIPTION
We speedup the gossip routines by using caches for LoadBlockPart, and making LoadBlockCommit no longer call Clone, as the caller does read-only operations to it.

This is a followup to https://github.com/cometbft/cometbft/pull/3003

This results in a net performance improvement, based on a 2hr sync on latest osmosis release, of:

    20% less RAM allocated over program lifetime. (76GB no longer allocated, 380 GB alloc total)
    50% speedup to gossipDataRoutine
    ~10% speedup to gossipVotesRoutine
    1% less overall system CPU usage. (If GC proportional to bytes allocated, then 5% less)

I have checked that every usage of LoadBlockPart and LoadBlockCommit do not modify the return value, so returning this underlying cache copy is safe for the current codebase

I used an ! in the title, since this is technically API breaking, even though all current usages are safe.