### PR TITLE
DNM: See if this helps scheduler load

### DIFF
--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -63,7 +63,7 @@ func (evR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 
 // AddPeer implements Reactor.
 func (evR *Reactor) AddPeer(peer p2p.Peer) {
-	go evR.broadcastEvidenceRoutine(peer)
+	// go evR.broadcastEvidenceRoutine(peer)
 }
 
 // Receive implements Reactor.


### PR DESCRIPTION
DO NOT MERGE

We see the scheduler load being high, we roughly have 7 long running goroutines per peer. I wanted to see what happens to the schedular load if we remove one with basically no cpu load. If it reduces, then we can optimize this to be one routine for all peers later. Otherwise ignore it for now