### PR TITLE
feat(p2p): render `HasChannel(chID)` is a public `p2p.Peer` method (#…

### DIFF
--- a/.changelog/unreleased/features/3472-p2p-has-channel-api.md
+++ b/.changelog/unreleased/features/3472-p2p-has-channel-api.md
@@ -1,0 +1,3 @@
+- `[p2p]` `HasChannel(chID)` method added to the `Peer` interface, used by
+  reactors to check whether a peer implements/supports a given channel.
+  ([#3472](https://github.com/cometbft/cometbft/issues/3472))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (I think)
 
+* [#128](https://github.com/osmosis-labs/cometbft/pull/128) feat(p2p): render HasChannel(chID) is a public p2p.Peer method (#3510)
 * [#123](https://github.com/osmosis-labs/cometbft/pull/123)  perf(p2p/conn): Remove unneeded global pool buffers in secret connection #3403 
 * perf(p2p): Delete expensive debug log already slated for deletion #3412 
 * perf(p2p): Reduce the p2p metrics overhead. #3411 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased (I think)
 
 * [#128](https://github.com/osmosis-labs/cometbft/pull/128) feat(p2p): render HasChannel(chID) is a public p2p.Peer method (#3510)
+* [#126]() Remove p2p allocations for wrapping outbound packets 
+* [#125]() Fix marshalling and concurrency overhead within broadcast routines 
+* perf(p2p): Only update send monitor once per batch packet msg send (#3382)
+* [#124]() Secret connection read buffer 
 * [#123](https://github.com/osmosis-labs/cometbft/pull/123)  perf(p2p/conn): Remove unneeded global pool buffers in secret connection #3403 
 * perf(p2p): Delete expensive debug log already slated for deletion #3412 
 * perf(p2p): Reduce the p2p metrics overhead. #3411 

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -583,6 +583,10 @@ func (conR *Reactor) getRoundState() *cstypes.RoundState {
 
 func (conR *Reactor) gossipDataRoutine(peer p2p.Peer, ps *PeerState) {
 	logger := conR.Logger.With("peer", peer)
+	if !peer.HasChannel(DataChannel) {
+		logger.Info("Peer does not implement DataChannel.")
+		return
+	}
 	rng := cmtrand.NewStdlibRand()
 
 OUTER_LOOP:
@@ -743,6 +747,10 @@ func (conR *Reactor) gossipDataForCatchup(logger log.Logger, rs *cstypes.RoundSt
 
 func (conR *Reactor) gossipVotesRoutine(peer p2p.Peer, ps *PeerState) {
 	logger := conR.Logger.With("peer", peer)
+	if !peer.HasChannel(VoteChannel) {
+		logger.Info("Peer does not implement VoteChannel.")
+		return
+	}
 	rng := cmtrand.NewStdlibRand()
 
 	// Simple hack to throttle logs upon sleep.

--- a/evidence/reactor.go
+++ b/evidence/reactor.go
@@ -63,7 +63,9 @@ func (evR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 
 // AddPeer implements Reactor.
 func (evR *Reactor) AddPeer(peer p2p.Peer) {
-	go evR.broadcastEvidenceRoutine(peer)
+	if peer.HasChannel(EvidenceChannel) {
+		go evR.broadcastEvidenceRoutine(peer)
+	}
 }
 
 // Receive implements Reactor.

--- a/evidence/reactor_test.go
+++ b/evidence/reactor_test.go
@@ -212,6 +212,7 @@ func TestReactorBroadcastEvidenceMemoryLeak(t *testing.T) {
 		e, ok := i.(p2p.Envelope)
 		return ok && e.ChannelID == evidence.EvidenceChannel
 	})).Return(false)
+	p.On("HasChannel", evidence.EvidenceChannel).Maybe().Return(true)
 	quitChan := make(<-chan struct{})
 	p.On("Quit").Return(quitChan)
 	ps := peerState{2}

--- a/mempool/v0/reactor.go
+++ b/mempool/v0/reactor.go
@@ -161,7 +161,7 @@ func (memR *Reactor) GetChannels() []*p2p.ChannelDescriptor {
 // AddPeer implements Reactor.
 // It starts a broadcast routine ensuring all txs are forwarded to the given peer.
 func (memR *Reactor) AddPeer(peer p2p.Peer) {
-	if memR.config.Broadcast {
+	if memR.config.Broadcast && peer.HasChannel(mempool.MempoolChannel) {
 		go func() {
 			// Always forward transactions to unconditional peers.
 			if !memR.Switch.IsPeerUnconditional(peer.ID()) {

--- a/p2p/mock/peer.go
+++ b/p2p/mock/peer.go
@@ -43,6 +43,7 @@ func NewPeer(ip net.IP) *Peer {
 }
 
 func (mp *Peer) FlushStop()                                      { mp.Stop() } //nolint:errcheck //ignore error
+func (mp *Peer) HasChannel(_ byte) bool                          { return true }
 func (mp *Peer) TrySendEnvelope(e p2p.Envelope) bool             { return true }
 func (mp *Peer) TrySendMarshalled(e p2p.MarshalledEnvelope) bool { return true }
 func (mp *Peer) SendEnvelope(e p2p.Envelope) bool                { return true }

--- a/p2p/mocks/peer.go
+++ b/p2p/mocks/peer.go
@@ -67,6 +67,24 @@ func (_m *Peer) GetRemovalFailed() bool {
 	return r0
 }
 
+// HasChannel provides a mock function with given fields: chID
+func (_m *Peer) HasChannel(chID byte) bool {
+	ret := _m.Called(chID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasChannel")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(byte) bool); ok {
+		r0 = rf(chID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // ID provides a mock function with given fields:
 func (_m *Peer) ID() p2p.ID {
 	ret := _m.Called()

--- a/p2p/peer_set_test.go
+++ b/p2p/peer_set_test.go
@@ -18,7 +18,8 @@ type mockPeer struct {
 	id ID
 }
 
-func (mp *mockPeer) FlushStop()                                  { mp.Stop() } //nolint:errcheck // ignore error
+func (mp *mockPeer) FlushStop()                                  { mp.Stop() } //nolint:errcheck // ignore erro
+func (mp *mockPeer) HasChannel(byte) bool                        { return true }
 func (mp *mockPeer) TrySendMarshalled(e MarshalledEnvelope) bool { return true }
 
 func (mp *mockPeer) TrySendEnvelope(e Envelope) bool { return true }

--- a/spec/p2p/reactor-api/p2p-api.md
+++ b/spec/p2p/reactor-api/p2p-api.md
@@ -181,15 +181,16 @@ From this point, reactors can use the methods of the new `Peer` instance.
 The table below summarizes the interaction of the standard reactors with
 connected peers, with the `Peer` methods used by them:
 
-| `Peer` API method                                     | consensus | block sync | state sync | mempool | evidence  | PEX   |
-|--------------------------------------------|-----------|------------|------------|---------|-----------|-------|
-| `ID() ID`                                  | x         | x          | x          | x       | x         | x     |
-| `IsRunning() bool`                         | x         |            |            | x       | x         |       |
-| `Quit() <-chan struct{}`                   |           |            |            | x       | x         |       |
-| `Get(string) interface{}`                  | x         |            |            | x       | x         |       |
-| `Set(string, interface{})`                 | x         |            |            |         |           |       |
-| `Send(Envelope) bool`                      | x         | x          | x          | x       | x         | x     |
-| `TrySend(Envelope) bool`                   | x         | x          |            |         |           |       |
+| `Peer` API method          | consensus | block sync | state sync | mempool | evidence | PEX |
+|----------------------------|-----------|------------|------------|---------|----------|-----|
+| `ID() ID`                  | x         | x          | x          | x       | x        | x   |
+| `IsRunning() bool`         | x         |            |            | x       | x        |     |
+| `Quit() <-chan struct{}`   |           |            |            | x       | x        |     |
+| `Get(string) interface{}`  | x         |            |            | x       | x        |     |
+| `Set(string, interface{})` | x         |            |            |         |          |     |
+| `HasChannel(byte) bool`    | x         |            |            | x       | x        |     |
+| `Send(Envelope) bool`      | x         | x          | x          | x       | x        | x   |
+| `TrySend(Envelope) bool`   | x         | x          |            |         |          |     |
 
 The above list is not exhaustive as it does not include all the `Peer` methods
 invoked by the PEX reactor, a special component that should be considered part
@@ -265,8 +266,10 @@ Finally, a `Peer` instance allows a reactor to send messages to companion
 reactors running at that peer.
 This is ultimately the goal of the switch when it provides `Peer` instances to
 the registered reactors.
-There are two methods for sending messages:
+There are two methods for sending messages, and one auxiliary method to check
+whether the peer supports a given channel:
 
+    func (p Peer) HasChannel(chID byte) bool
     func (p Peer) Send(e Envelope) bool
     func (p Peer) TrySend(e Envelope) bool
 
@@ -275,6 +278,9 @@ set as follows:
 
 - `ChannelID`: the channel the message should be sent through, which defines
   the reactor that will process the message;
+  - The auxiliary `HasChannel()` method allows testing whether the remote peer
+    implements a channel; if it does not, both message-sending methods will
+    immediately return `false`, as sending always fails.
 - `Src`: this field represents the source of an incoming message, which is
   irrelevant for outgoing messages;
 - `Message`: the actual message's payload, which is marshalled using protocol buffers.

--- a/test/fuzz/p2p/pex/reactor_receive.go
+++ b/test/fuzz/p2p/pex/reactor_receive.go
@@ -85,17 +85,19 @@ func (fp *fuzzPeer) RemoteIP() net.IP { return net.IPv4(0, 0, 0, 0) }
 func (fp *fuzzPeer) RemoteAddr() net.Addr {
 	return &net.TCPAddr{IP: fp.RemoteIP(), Port: 98991, Zone: ""}
 }
-func (fp *fuzzPeer) IsOutbound() bool                    { return false }
-func (fp *fuzzPeer) IsPersistent() bool                  { return false }
-func (fp *fuzzPeer) CloseConn() error                    { return nil }
-func (fp *fuzzPeer) NodeInfo() p2p.NodeInfo              { return defaultNodeInfo }
-func (fp *fuzzPeer) Status() p2p.ConnectionStatus        { var cs p2p.ConnectionStatus; return cs }
-func (fp *fuzzPeer) SocketAddr() *p2p.NetAddress         { return p2p.NewNetAddress(fp.ID(), fp.RemoteAddr()) }
-func (fp *fuzzPeer) SendEnvelope(e p2p.Envelope) bool    { return true }
-func (fp *fuzzPeer) TrySendEnvelope(e p2p.Envelope) bool { return true }
-func (fp *fuzzPeer) Send(_ byte, _ []byte) bool          { return true }
-func (fp *fuzzPeer) TrySend(_ byte, _ []byte) bool       { return true }
-func (fp *fuzzPeer) Set(key string, value interface{})   { fp.m[key] = value }
-func (fp *fuzzPeer) Get(key string) interface{}          { return fp.m[key] }
-func (fp *fuzzPeer) GetRemovalFailed() bool              { return false }
-func (fp *fuzzPeer) SetRemovalFailed()                   {}
+func (fp *fuzzPeer) IsOutbound() bool                                { return false }
+func (fp *fuzzPeer) IsPersistent() bool                              { return false }
+func (fp *fuzzPeer) CloseConn() error                                { return nil }
+func (fp *fuzzPeer) NodeInfo() p2p.NodeInfo                          { return defaultNodeInfo }
+func (fp *fuzzPeer) Status() p2p.ConnectionStatus                    { var cs p2p.ConnectionStatus; return cs }
+func (fp *fuzzPeer) SocketAddr() *p2p.NetAddress                     { return p2p.NewNetAddress(fp.ID(), fp.RemoteAddr()) }
+func (fp *fuzzPeer) HasChannel(byte) bool                            { return true }
+func (fp *fuzzPeer) SendEnvelope(e p2p.Envelope) bool                { return true }
+func (fp *fuzzPeer) TrySendEnvelope(e p2p.Envelope) bool             { return true }
+func (fp *fuzzPeer) TrySendMarshalled(e p2p.MarshalledEnvelope) bool { return true }
+func (fp *fuzzPeer) Send(_ byte, _ []byte) bool                      { return true }
+func (fp *fuzzPeer) TrySend(_ byte, _ []byte) bool                   { return true }
+func (fp *fuzzPeer) Set(key string, value interface{})               { fp.m[key] = value }
+func (fp *fuzzPeer) Get(key string) interface{}                      { return fp.m[key] }
+func (fp *fuzzPeer) GetRemovalFailed() bool                          { return false }
+func (fp *fuzzPeer) SetRemovalFailed()                               {}


### PR DESCRIPTION
…3510)

Closes: #3472

It also prevents reactors from starting routines intended to send messages to a peer that does not implement/support a given channel. Because all `Send()` or `TrySend()` calls from this routine will be useless, always returning `false` and possibly producing some busy-wait behavior (see https://github.com/cometbft/cometbft/issues/3414).

The changes are restricted to: mempool and evidence reactor, because they use a single channel and have a sending routine peer peer, and two of the consensus routines, for Data and Votes.

Block and State sync reactors have smarter ways to deal with unresponsive peers, so probably this check is not needed.

---

- [x] Tests written/updated
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

