### PR TITLE
perf(p2p): Remove broadcast return channel (backport #3182) (#3480)

### DIFF
--- a/.changelog/v0.38.8/improvements/3182-remove-switch-broadcast-return-channel.md
+++ b/.changelog/v0.38.8/improvements/3182-remove-switch-broadcast-return-channel.md
@@ -1,0 +1,2 @@
+- `[p2p]` Remove `Switch#Broadcast` unused return channel
+  ([\#3182](https://github.com/cometbft/cometbft/pull/3182))

--- a/p2p/switch_test.go
+++ b/p2p/switch_test.go
@@ -840,22 +840,11 @@ func BenchmarkSwitchBroadcast(b *testing.B) {
 
 	b.ResetTimer()
 
-	numSuccess, numFailure := 0, 0
-
 	// Send random message from foo channel to another
 	for i := 0; i < b.N; i++ {
 		chID := byte(i % 4)
-		successChan := s1.Broadcast(Envelope{ChannelID: chID})
-		for s := range successChan {
-			if s {
-				numSuccess++
-			} else {
-				numFailure++
-			}
-		}
+		s1.Broadcast(Envelope{ChannelID: chID})
 	}
-
-	b.Logf("success: %v, failure: %v", numSuccess, numFailure)
 }
 
 func TestSwitchRemovalErr(t *testing.T) {


### PR DESCRIPTION
Remove the return channel and waitgroup from switch.Broadcast as its unused. This was costing us some CPU overhead (2% of broadcast routine as it stands right now, but broadcast routine time should be dropping) and one extra goroutine. This removes more overhead than what #3180 may introduce.

It also better highlights the point that maybe all broadcast usecases should consider using TrySend (And we potentially adapt channel buffers), ala the point in #3151 . (This would have significant system-wide impact, by significantly lowering the number of timers/scheduler overhead we have)

---

- [x] Tests written/updated - Simplifies code, the behavior being removed was never tested!
- [x] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec <hr>This is an automatic backport of pull request #3182 done by [Mergify](https://mergify.com).

---------

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

