### PR TITLE
fix: comment out expensive debug logs

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1395,12 +1395,12 @@ func (ps *PeerState) SetHasVoteFromPeer(vote *types.Vote, csHeight int64, valSiz
 }
 
 func (ps *PeerState) setHasVote(height int64, round int32, voteType cmtproto.SignedMsgType, index int32) {
-	ps.logger.Debug("setHasVote",
-		"peerH/R",
-		log.NewLazySprintf("%d/%d", ps.PRS.Height, ps.PRS.Round),
-		"H/R",
-		log.NewLazySprintf("%d/%d", height, round),
-		"type", voteType, "index", index)
+	//	ps.logger.Debug("setHasVote",
+	//		"peerH/R",
+	//		log.NewLazySprintf("%d/%d", ps.PRS.Height, ps.PRS.Round),
+	//		"H/R",
+	//		log.NewLazySprintf("%d/%d", height, round),
+	//		"type", voteType, "index", index)
 
 	// NOTE: some may be nil BitArrays -> no side effects.
 	psVotes := ps.getVoteBitArray(height, round, voteType)

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2211,7 +2211,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 			return added, err
 		}
 
-		cs.Logger.Debug("added vote to last precommits", "last_commit", cs.LastCommit.StringShort())
+		// cs.Logger.Debug("added vote to last precommits", "last_commit", cs.LastCommit.StringShort())
 		if err := cs.eventBus.PublishEventVote(types.EventDataVote{Vote: vote}); err != nil {
 			return added, err
 		}
@@ -2303,7 +2303,7 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 	switch vote.Type {
 	case cmtproto.PrevoteType:
 		prevotes := cs.Votes.Prevotes(vote.Round)
-		cs.Logger.Debug("added vote to prevote", "vote", vote, "prevotes", prevotes.StringShort())
+		// cs.Logger.Debug("added vote to prevote", "vote", vote, "prevotes", prevotes.StringShort())
 
 		// If +2/3 prevotes for a block or nil for *any* round:
 		if blockID, ok := prevotes.TwoThirdsMajority(); ok {
@@ -2338,11 +2338,11 @@ func (cs *State) addVote(vote *types.Vote, peerID p2p.ID) (added bool, err error
 					cs.ValidBlock = cs.ProposalBlock
 					cs.ValidBlockParts = cs.ProposalBlockParts
 				} else {
-					cs.Logger.Debug(
-						"valid block we do not know about; set ProposalBlock=nil",
-						"proposal", log.NewLazyBlockHash(cs.ProposalBlock),
-						"block_id", blockID.Hash,
-					)
+					// cs.Logger.Debug(
+					// 	"valid block we do not know about; set ProposalBlock=nil",
+					// 	"proposal", log.NewLazyBlockHash(cs.ProposalBlock),
+					// 	"block_id", blockID.Hash,
+					// )
 
 					// we're getting the wrong block
 					cs.ProposalBlock = nil

--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -360,7 +360,7 @@ func (c *MConnection) Send(chID byte, msgBytes []byte) bool {
 		return false
 	}
 
-	c.Logger.Debug("Send", "channel", chID, "conn", c, "msgBytes", log.NewLazySprintf("%X", msgBytes))
+	// c.Logger.Debug("Send", "channel", chID, "conn", c, "msgBytes", log.NewLazySprintf("%X", msgBytes))
 
 	// Send message to channel.
 	channel, ok := c.channelsIdx[chID]
@@ -377,7 +377,7 @@ func (c *MConnection) Send(chID byte, msgBytes []byte) bool {
 		default:
 		}
 	} else {
-		c.Logger.Debug("Send failed", "channel", chID, "conn", c, "msgBytes", log.NewLazySprintf("%X", msgBytes))
+		// c.Logger.Debug("Send failed", "channel", chID, "conn", c, "msgBytes", log.NewLazySprintf("%X", msgBytes))
 	}
 	return success
 }
@@ -389,7 +389,7 @@ func (c *MConnection) TrySend(chID byte, msgBytes []byte) bool {
 		return false
 	}
 
-	c.Logger.Debug("TrySend", "channel", chID, "conn", c, "msgBytes", log.NewLazySprintf("%X", msgBytes))
+	// c.Logger.Debug("TrySend", "channel", chID, "conn", c, "msgBytes", log.NewLazySprintf("%X", msgBytes))
 
 	// Send message to channel.
 	channel, ok := c.channelsIdx[chID]

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -319,13 +319,13 @@ func (p *peer) HasChannel(chID byte) bool {
 	}
 	// NOTE: probably will want to remove this
 	// but could be helpful while the feature is new
-	p.Logger.Debug(
-		"Unknown channel for peer",
-		"channel",
-		chID,
-		"channels",
-		p.channels,
-	)
+	// p.Logger.Debug(
+	// 	"Unknown channel for peer",
+	// 	"channel",
+	// 	chID,
+	// 	"channels",
+	// 	p.channels,
+	// )
 	return false
 }
 


### PR DESCRIPTION
Comment out some expensive logs. We'll switch to https://github.com/cometbft/cometbft/pull/2989 in when it's merged, but doing this for now as its become more problematic with the increased gossip routine speed we are going for.